### PR TITLE
Improves Identifier type and Testing

### DIFF
--- a/model/skipgraph/identifier.go
+++ b/model/skipgraph/identifier.go
@@ -22,6 +22,11 @@ func (i Identifier) String() string {
 	return hex.EncodeToString(i[:])
 }
 
+// Bytes returns the byte representation of an Identifier.
+func (i Identifier) Bytes() []byte {
+	return i[:]
+}
+
 // Compare compares two Identifiers and returns 0 if equal, 1 if other > i and -1 if other < i.
 func (i Identifier) Compare(other Identifier) string {
 	cmp := bytes.Compare(i[:], other[:])
@@ -35,33 +40,35 @@ func (i Identifier) Compare(other Identifier) string {
 	}
 }
 
-// ToIdentifier converts a byte slice b to an Identifier.
-// returns error if the length of b is more than Identifier's length i.e., 32 bytes.
-func ToIdentifier(b []byte) (Identifier, error) {
+// ByteToId converts a byte slice b to an Identifier.
+// Returns error if the length of b is more than Identifier's length i.e., 32 bytes.
+// If the length of b is less than 32 bytes, it is zero padded from the left.
+// It follows a big-endian representation where the 0 index of the byte slice corresponds to the most significant byte.
+// Args:
+//
+//	b: the byte slice to be converted to an Identifier
+//
+// Returns:
+//
+//	Identifier: the converted Identifier
+//	error: if the length of b is more than 32 bytes
+func ByteToId(b []byte) (Identifier, error) {
 	res := Identifier{0}
-	if len(b) > 32 {
-		return res, fmt.Errorf("input length must be at most 32 bytes; found: %d", len(b))
+	if len(b) > IdentifierSize {
+		return res, fmt.Errorf("input length must be at most %d bytes; found: %d", IdentifierSize, len(b))
 	}
-	index := 31
-	for i := len(b) - 1; i >= 0; i-- {
-		res[index] = b[i]
-		index--
-	}
+	offset := IdentifierSize - len(b)
+	copy(res[offset:], b)
 	return res, nil
 }
 
-// StringToIdentifier converts a string to an Identifier.
+// StrToId converts a string to an Identifier.
 // returns error if the byte length of the string s is more than Identifier's length i.e., 32 bytes.
-func StringToIdentifier(s string) (Identifier, error) {
-	b := []byte(s)
-	res := Identifier{0}
-	if len(b) > 32 {
-		return res, fmt.Errorf("input length must be at most 32 bytes; found: %d", len(b))
+func StrToId(s string) (Identifier, error) {
+	// converts string to byte
+	b, err := hex.DecodeString(s)
+	if err != nil {
+		return Identifier{}, fmt.Errorf("failed to decode hex string: %s", err)
 	}
-	index := 31
-	for i := len(b) - 1; i >= 0; i-- {
-		res[index] = b[i]
-		index--
-	}
-	return res, nil
+	return ByteToId(b)
 }

--- a/model/skipgraph/identifier_test.go
+++ b/model/skipgraph/identifier_test.go
@@ -1,8 +1,10 @@
 package skipgraph_test
 
 import (
+	"bytes"
 	"github.com/stretchr/testify/require"
 	"github/yhassanzadeh13/skipgraph-go/model/skipgraph"
+	"github/yhassanzadeh13/skipgraph-go/unittest"
 	"testing"
 )
 
@@ -11,15 +13,46 @@ func TestCompare(t *testing.T) {
 	s1 := []byte("12")
 	s2 := []byte("22")
 	s3 := []byte("12")
-	i1, err := skipgraph.ToIdentifier(s1)
+	i1, err := skipgraph.ByteToId(s1)
 	require.NoError(t, err)
-	i2, err := skipgraph.ToIdentifier(s2)
+	i2, err := skipgraph.ByteToId(s2)
 	require.NoError(t, err)
-	i3, err := skipgraph.ToIdentifier(s3)
+	i3, err := skipgraph.ByteToId(s3)
 	require.NoError(t, err)
 
 	require.Equal(t, skipgraph.CompareLess, i1.Compare(i2))
 	require.Equal(t, skipgraph.CompareGreater, i2.Compare(i1))
 	require.Equal(t, skipgraph.CompareEqual, i1.Compare(i3))
+}
+
+func TestIdentifier_Bytes(t *testing.T) {
+	// 32 bytes of zero
+	b := bytes.Repeat([]byte{0}, skipgraph.IdentifierSize)
+	id, err := skipgraph.ByteToId(b)
+	require.NoError(t, err)
+	require.Equal(t, b, id.Bytes())
+
+	// 32 bytes of 1
+	b = bytes.Repeat([]byte{255}, skipgraph.IdentifierSize)
+	id, err = skipgraph.ByteToId(b)
+	require.NoError(t, err)
+	require.Equal(t, b, id.Bytes())
+
+	// 32 random bytes
+	b = unittest.RandomBytesFixture(t, skipgraph.IdentifierSize)
+	id, err = skipgraph.ByteToId(b)
+	require.NoError(t, err)
+	require.Equal(t, b, id.Bytes())
+
+	// 31 random bytes should be zero padded
+	b = unittest.RandomBytesFixture(t, skipgraph.IdentifierSize-1)
+	id, err = skipgraph.ByteToId(b)
+	require.NoError(t, err)
+	unittest.MustHaveZeroPrefixBytes(t, id.Bytes(), 1, b...)
+
+	// 33 random bytes should return an error
+	b = unittest.RandomBytesFixture(t, skipgraph.IdentifierSize+1)
+	_, err = skipgraph.ByteToId(b)
+	require.Error(t, err)
 
 }

--- a/unittest/bytes.go
+++ b/unittest/bytes.go
@@ -1,0 +1,22 @@
+package unittest
+
+import (
+	"github.com/stretchr/testify/require"
+	"testing"
+)
+
+// MustHaveZeroPrefixBytes checks if the given byte slice has zero prefix of the given length and the rest of the bytes are equal to the given bytes.
+// Args:
+//
+//	t: the testing.T instance
+//	b: the byte slice to be checked
+//	zeroPrefix: the length of the zero prefix
+//	rest: the rest of the bytes to be checked (optional)
+func MustHaveZeroPrefixBytes(t *testing.T, b []byte, zeroPrefix int, rest ...byte) {
+	for i := 0; i < zeroPrefix; i++ {
+		require.Equal(t, byte(0), b[i], "byte %d is not zero", i)
+	}
+	for i, r := range rest {
+		require.Equal(t, r, b[zeroPrefix+i], "byte %d is not equal to %d", zeroPrefix+i, r)
+	}
+}


### PR DESCRIPTION
This pull request includes several changes to the `model/skipgraph` package, focusing on improving the `Identifier` type methods and enhancing the testing framework. The most important changes include the addition of new methods for `Identifier`, renaming and refactoring of existing methods for better clarity, and adding new test cases to ensure the correctness of these methods.

Enhancements to `Identifier` type methods:

* Added a new `Bytes` method to return the byte representation of an `Identifier`. (`model/skipgraph/identifier.go`, [model/skipgraph/identifier.goR25-R29](diffhunk://#diff-e0dc7d145178e3963d0f49815e7e9ffaef163459428bb29bcd339c87633b20fdR25-R29))
* Renamed and refactored the `ToIdentifier` method to `ByteToId`, including zero-padding for byte slices shorter than 32 bytes and providing detailed comments. (`model/skipgraph/identifier.go`, [model/skipgraph/identifier.goL38-R73](diffhunk://#diff-e0dc7d145178e3963d0f49815e7e9ffaef163459428bb29bcd339c87633b20fdL38-R73))
* Renamed and refactored the `StringToIdentifier` method to `StrToId`, converting a hex string to an `Identifier` using the new `ByteToId` method. (`model/skipgraph/identifier.go`, [model/skipgraph/identifier.goL38-R73](diffhunk://#diff-e0dc7d145178e3963d0f49815e7e9ffaef163459428bb29bcd339c87633b20fdL38-R73))

Improvements to testing:

* Added new test cases for the `Bytes` method to ensure correct byte representation and zero-padding behavior. (`model/skipgraph/identifier_test.go`, [model/skipgraph/identifier_test.goL14-R56](diffhunk://#diff-7ede77dbb772aaa04fdcec3c37b59a0955e9b7d5cb6d12e69b4942724ea9943cL14-R56))
* Introduced a new utility function `MustHaveZeroPrefixBytes` in the `unittest` package to verify zero-padded byte slices in tests. (`unittest/bytes.go`, [unittest/bytes.goR1-R22](diffhunk://#diff-0a42ce472aaa7dd40328a21ed5d840397167621c752aa97028ff708118cf2697R1-R22))