### PR TITLE
chore: bumps go version to go1.23

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,7 +43,7 @@ jobs:
       fail-fast: false
       matrix:
         go-version:
-          - 1.16
+          - 1.23
     runs-on: ubuntu-latest
     steps:
     - name: Check Go Version

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ jobs:
       fail-fast: true
       matrix:
         go-version:
-          - 1.16
+          - 1.23
     runs-on: ubuntu-latest
     steps:
       - name: Check Go Version

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,7 +43,7 @@ jobs:
       fail-fast: false
       matrix:
         go-version:
-          - 1.23
+          - 1.23 # Add more versions here if needed
     runs-on: ubuntu-latest
     steps:
     - name: Check Go Version

--- a/README.md
+++ b/README.md
@@ -29,6 +29,6 @@ make test
 
 ## Requirements
 
-- Go 1.16 or later
+- Go 1.23 or later
 
 

--- a/go.mod
+++ b/go.mod
@@ -1,5 +1,11 @@
 module github/yhassanzadeh13/skipgraph-go
 
-go 1.16
+go 1.23
 
 require github.com/stretchr/testify v1.7.0
+
+require (
+	github.com/davecgh/go-spew v1.1.0 // indirect
+	github.com/pmezard/go-difflib v1.0.0 // indirect
+	gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c // indirect
+)

--- a/unittest/fixtures.go
+++ b/unittest/fixtures.go
@@ -1,12 +1,12 @@
 package unittest
 
 import (
+	"crypto/rand"
 	"github.com/stretchr/testify/require"
 	"github/yhassanzadeh13/skipgraph-go/model"
 	"github/yhassanzadeh13/skipgraph-go/model/messages"
 	"github/yhassanzadeh13/skipgraph-go/model/skipgraph"
-	"math/rand"
-	"strconv"
+	"math/big"
 	"testing"
 )
 
@@ -63,7 +63,9 @@ func MembershipVectorFixture(t *testing.T) skipgraph.MembershipVector {
 // AddressFixture returns an Address on localhost with a random port number.
 func AddressFixture(t *testing.T) model.Address {
 	// pick a random port
-	port := strconv.Itoa(rand.Intn(65535))
+	max := big.NewInt(65535)
+	randomInt, _ := rand.Int(rand.Reader, max)
+	port := randomInt.String()
 	addr := model.NewAddress("localhost", port)
 	return addr
 


### PR DESCRIPTION
This pull request includes several updates to improve compatibility with Go 1.23, update dependencies, and enhance the randomness in unit tests. The most important changes include updating the Go version, modifying the `go.mod` file to include new indirect dependencies, and replacing the `math/rand` package with `crypto/rand` for better randomness in unit tests.

Updates for Go version compatibility:

* [`.github/workflows/ci.yml`](diffhunk://#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03fL46-R46): Updated the Go version in the CI configuration from 1.16 to 1.23.
* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L32-R32): Updated the Go version requirement from 1.16 to 1.23.
* [`go.mod`](diffhunk://#diff-33ef32bf6c23acb95f5902d7097b7a1d5128ca061167ec0716715b0b9eeaa5f6L3-R11): Updated the Go version from 1.16 to 1.23 and added new indirect dependencies.

Enhancements to unit tests:

* [`unittest/fixtures.go`](diffhunk://#diff-688b18fe32fca14adb22a2062e9aec210935940c65915139c18b800232e8dbcfR4-R9): Replaced the `math/rand` package with `crypto/rand` for generating random port numbers, improving the randomness and security of the tests. [[1]](diffhunk://#diff-688b18fe32fca14adb22a2062e9aec210935940c65915139c18b800232e8dbcfR4-R9) [[2]](diffhunk://#diff-688b18fe32fca14adb22a2062e9aec210935940c65915139c18b800232e8dbcfL66-R68)