### PR TITLE
Refactors CI/CD pipeline and adds linting

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,9 +2,9 @@ name: CI
 
 on:
   push:
-    branches: [ master ]
+    branches: [ main ]
   pull_request:
-    branches: [ master ]
+    branches: [ main ]
 
 jobs:
   build:
@@ -13,15 +13,15 @@ jobs:
       fail-fast: true
       matrix:
         go-version:
-          - 1.23
+          - '1.24'
     runs-on: ubuntu-latest
     steps:
       - name: Check Go Version
-        uses: actions/setup-go@v2
+        uses: actions/setup-go@v4
         with:
           go-version: ${{matrix.go-version}}
       - name: Checkout repo
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
       - name: builds the code
         run: make build
       
@@ -30,12 +30,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v2
-    - name: Run linter
-      uses: golangci/golangci-lint-action@v2.3.0
-      with:
-        version: v1.63.4
-    
+      uses: actions/checkout@v4
+    - name: Install Linter
+      run: curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $GITHUB_WORKSPACE/bin v1.54.2
+    - name: Run Linter
+      run: $GITHUB_WORKSPACE/bin/golangci-lint run --config integration/golangci-lint.yml ./...
     
   unittest:
     name: Unit Tests
@@ -43,14 +42,14 @@ jobs:
       fail-fast: false
       matrix:
         go-version:
-          - 1.23 # Add more versions here if needed
+          - '1.23'
     runs-on: ubuntu-latest
     steps:
     - name: Check Go Version
-      uses: actions/setup-go@v2
+      uses: actions/setup-go@v4
       with:
         go-version: ${{matrix.go-version}}
     - name: Checkout repo
-      uses: actions/checkout@v2
+      uses: actions/checkout@v4
     - name: Run tests
-      run: make test
+      run: go test -v ./...

--- a/Makefile
+++ b/Makefile
@@ -1,10 +1,63 @@
-tidy:
-	go mod tidy
-lint:
-	golangci-lint run ./...
-lint-fix:
-	golangci-lint run --fix ./...
-test:
-	go test ./...
-build:
-	go build -v ./...
+# Minimum Go version
+GO_MIN_VERSION := 1.23.0
+LINT_VERSION := v1.64.5
+
+# Dynamically detect OS (e.g., darwin, linux) and architecture (amd64, arm64)
+GO_OS := $(shell uname -s | tr A-Z a-z)
+GO_ARCH := $(shell uname -m | sed 's/x86_64/amd64/' | sed 's/arm64/arm64/')
+
+# Download URL for the Go package
+GO_DOWNLOAD_URL := https://golang.org/dl/go$(GO_MIN_VERSION).$(GO_OS)-$(GO_ARCH).tar.gz
+
+# Go installation directory and binary path
+GO_INSTALL_DIR := /usr/local/go
+GO_BIN := $(shell which go)
+
+# Hook to check Go version before running any target
+.PHONY: check-go-version
+check-go-version:
+	@if [ -x "$(GO_BIN)" ]; then \
+		CURRENT=$$($(GO_BIN) version | grep -o 'go[0-9]\+\(\.[0-9]\+\)*' | sed 's/go//'); \
+		DESIRED="$(GO_MIN_VERSION)"; \
+		if [ "$$(printf '%s\n' "$$DESIRED" "$$CURRENT" | sort -V | head -n1)" != "$$DESIRED" ]; then \
+			echo "⚠️  Current Go version ($$CURRENT) does not meet the minimum required version ($$DESIRED)."; \
+			exit 1; \
+		else \
+			echo "✅ Current Go version ($$CURRENT) meets or exceeds the required version ($$DESIRED)."; \
+		fi; \
+	else \
+		echo "❌ Go is not installed."; \
+		exit 1; \
+	fi
+
+# Install tools target with a dependency on Go version check
+.PHONY: install-tools
+install-tools: check-go-version
+	@echo "Installing other tools..."
+	@if ! command -v golangci-lint >/dev/null 2>&1; then \
+		echo "🔧 Installing golangci-lint..."; \
+		go install github.com/golangci/golangci-lint/cmd/golangci-lint@$(LINT_VERSION); \
+	else \
+		VERSION=$$(golangci-lint --version --format "{{.Version}}"); \
+		if [[ "$${VERSION}" != "$(LINT_VERSION)" ]]; then \
+			echo "🔄 Updating/Downgrading golangci-lint to $(LINT_VERSION)..."; \
+			go clean -i github.com/golangci/golangci-lint/cmd/golangci-lint; \
+			go install github.com/golangci/golangci-lint/cmd/golangci-lint@$(LINT_VERSION); \
+		else \
+			echo "✅ golangci-lint $(LINT_VERSION) is already installed."; \
+		fi; \
+	fi
+	@echo "✅ All tools installed successfully."
+
+
+
+# Linting target with a dependency on Go version check
+.PHONY: lint-fix
+lint: check-go-version tidy
+	 @echo "Running golangci-lint..."
+	 @golangci-lint run --fix --config ./integration/golangci-lint.yml ./...
+
+.PHONY: tidy
+tidy: check-go-version
+	@echo "Running go mod tidy..."
+	@go mod tidy

--- a/integration/golangci-lint.yml
+++ b/integration/golangci-lint.yml
@@ -1,0 +1,14 @@
+run:
+  timeout: 2m
+
+linters:
+  enable:
+    - govet
+    - errcheck
+    - staticcheck
+    - gofmt
+    - gosimple
+    - unused
+
+issues:
+  exclude-use-default: false


### PR DESCRIPTION
Updates the CI/CD pipeline to use newer GitHub Actions, upgrade the Go version, and improve the linting process.

Introduces a `Makefile` to streamline build, linting, and testing, as well as Go version management. It will now install tools, and manage Go dependencies.

Uses golangci-lint for static code analysis.

Removes the old Makefile.